### PR TITLE
Fixes tiny typo in app menu

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -89,7 +89,7 @@
     <div class="menu_list">
       <div id="tool_about" class="menu_item">About this Editor...</div>
       <div class="separator"></div>
-      <div id="tool_about" class="menu_item">Keyboard Shortcus...</div>
+      <div id="tool_about" class="menu_item">Keyboard Shortcuts...</div>
     </div>
   </a>
   

--- a/method-draw/index.html
+++ b/method-draw/index.html
@@ -89,7 +89,7 @@
     <div class="menu_list">
       <div id="tool_about" class="menu_item">About this Editor...</div>
       <div class="separator"></div>
-      <div id="tool_about" class="menu_item">Keyboard Shortcus...</div>
+      <div id="tool_about" class="menu_item">Keyboard Shortcuts...</div>
     </div>
   </a>
   


### PR DESCRIPTION
I think `Shortcus` should be `Shortcuts`. The Devil is in the details they say. They probably didn't mean typos, but hey...