### PR TITLE
Fix canvas resize animation

### DIFF
--- a/editor/src/method-draw.js
+++ b/editor/src/method-draw.js
@@ -3196,10 +3196,11 @@
 					var diff_w = dims[0] - w.value;
 					var diff_h = dims[1] - h.value;
 					//animate
-					var start = Date.now();
+					var start = null;
 					var duration = 1000;
 					var animateCanvasSize = function(timestamp) {
-					  var progress = timestamp - start
+						if (start === null) start = timestamp
+						var progress = timestamp - start
 					  var tick = progress / duration
             tick = (Math.pow((tick-1), 3) +1);
 					  w.value = (dims[0] - diff_w + (tick*diff_w)).toFixed(0);
@@ -3215,7 +3216,7 @@
 					    requestAnimationFrame(animateCanvasSize)
 					  }
 					}
-					animateCanvasSize(Date.now())
+					requestAnimationFrame(animateCanvasSize)
 
 				}
 			});


### PR DESCRIPTION
Currently when we resize, by selecting the size in the dropdown, the editor goes into a infinite loop.

**Expected behavior:**
Resize the canvas gradually, with a nice animation. 

**Repro:**
1. Choose a different size.
2. Check that the animation is performed correctly.

**Browsers:**
Verified in Chrome 29.0.1547.65, Firefox 23.0.1